### PR TITLE
distribution methods 

### DIFF
--- a/docs/distribution_methods.md
+++ b/docs/distribution_methods.md
@@ -1,1 +1,39 @@
 # Mobile App Distribution Methods
+
+Mobile apps are distributed either through the public app stores or   MDM InTune. Please review the diagram below to determine the distribution method for your app.
+
+![Diagram of the various distribution methods. If the app is for the general public, it is distributed via the Apple App Store and Google Play Stores. If it is an app for Government Employees, it is distributed via MDM inTunes. If it is an app for Employees and Contractors it is distributed as an unlisted app via the Apple App Store](assets/distribution.drawio.svg)
+
+Public apps are released through the Province's accounts on Apple's App Store and Google's Play Store. You must list your app through the Province's accounts. The developer experience team will assist you in setting up your app on these accounts.  Please refer to the [project initiation](initiate.md) page for the information needed to setup an app. Once setup you will have access to [App Store Connect](https://appstoreconnect.apple.com) and [Google Play Console](https://play.google.com/console/about/) to manage your app.
+
+Both the Apple App Store and Google Play Store have an app review process. When creating your app, it is important to consider how the app reviewer will interact with your app. For instance, if your app requires a login, the app reviewer will need either an account or access to a demo account. If your internal app cannot go through the app review process, please inform the [developer experience team](mailto:Developer.Experience@gov.bc.ca).
+
+Please consult [Apple's app guidelines](https://developer.apple.com/app-store/review/) and [Google's app guidelines](https://support.google.com/googleplay/android-developer/answer/9859455?hl=en&ref_topic=7072031&sjid=10634496881788336983-NA) when preparing your app's release. It is important to follow their guidelines to ensure a smooth app review process.
+
+Employee apps are distributed through [MDM inTune by the OCIO Device Management Team](https://citz.sp.gov.bc.ca/sites/ES/DS/MDAS/Docs/SitePages/Home.aspx). While historically employee apps only supported iOS devices, it is possible for Android support. If you are planning to create an internal Android app, please contact us. You will be the first app and will need extra setup.
+
+Employee and contractor apps also need extra setup in Apple's App Store Connect. The developer experience team will assist in this setup.
+
+## Beta Testing Distribution
+
+An app can be distributed for beta testing before its official release. 
+
+Apple offers [TestFlight](https://developer.apple.com/testflight/) and Google offers [open, closed and internal testing](https://support.google.com/googleplay/android-developer/answer/9845334?_ga=2.46417955.584331364.1687196439-22968901.1675209271&_gac=1.16068354.1687196439.EAIaIQobChMImu70vvDP_wIV4w6tBh0qkAu2EAAYASAAEgIVwvD_BwE). Both platforms allow you to invite testers to try out your app on their devices before its official release. This provides an opportunity to gather feedback and make improvements before the public launch.
+
+
+## Further Reading
+
+### Apple Documentation
+* [App Store Connect Documentation](https://developer.apple.com/help/app-store-connect/)
+* [Distribution Methods](https://developer.apple.com/help/app-store-connect/manage-your-apps-availability/set-distribution-methods)
+* [App Distribution – From Ad-hoc to Enterprise](https://developer.apple.com/videos/play/wwdc2019/304/)
+* [Explore unlisted app distribution](https://developer.apple.com/videos/play/tech-talks/10892/)
+
+### Google Documentation
+
+* [Google Play Console Documentation](https://support.google.com/googleplay/android-developer/?hl=en&sjid=10634496881788336983-NA#topic=7071529)
+* [Control when app changes are reviewed and published](https://support.google.com/googleplay/android-developer/answer/9859654?hl=en&ref_topic=7072031&sjid=10634496881788336983-NA)
+* [Publish private apps](https://support.google.com/googleplay/work/answer/6145139?sjid=10634496881788336983-NA)
+
+
+If you have any further questions, please don't hesitate to contact the [developer experience team](mailto:Developer.Experience@gov.bc.ca). We are here to support you throughout the process.


### PR DESCRIPTION
The page can be viewed [here](https://f5ff48-developer-portal-dev-f5ff48-dev.apps.silver.devops.gov.bc.ca/docs/default/Component/mobile-developer-guide/distribution_methods/)

It is rewritten from [the mobile signing service wiki](https://github.com/bcgov/mobile-signing-service/wiki/Apple-Distribution-Methods) and the [deployment section](https://developer.gov.bc.ca/Mobile-Starter-Kit-Overview#deployment) in the Mobile Starter Kit.

Note: The Enterprise method was removed from the new documents on purpose. If teams have a need for it we can set them up, but we do not want it to be their first option. 