### PR TITLE
encryption regulations

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,20 @@
+# Export Encryption Compliance
+
+Your app must abide by [U.S. export restrictions](https://www.bis.doc.gov/index.php/policy-guidance/encryption) if it is available for download outside of the U.S. or Canada. This is because both Apple and Google's app store servers are in the United States. If a user from another country downloads the app, it is from a U.S. server. Thus, the server exports the app to another country.
+
+
+## Apple App Store
+
+Use [App Store Connect's tool](https://developer.apple.com/help/app-store-connect/manage-app-information/detemine-and-upload-export-compliance-documentation) to determine if you need compliance documentation. Once you know your [app's export compliance](https://developer.apple.com/help/app-store-connect/reference/export-compliance-documentation-for-encryption), you can [Declare Your App’s Use of Encryption](https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations) in the [Info.plist](https://developer.apple.com/documentation/bundleresources/information_property_list) file. Future app submissions will no longer need to answer compliance review questions.
+
+Please refer to Apple's [Overview of export compliance](https://developer.apple.com/help/app-store-connect/manage-app-information/overview-of-export-compliance) for further details.
+
+## Google Play Store
+
+Please see Google's [Export compliance](https://support.google.com/googleplay/android-developer/answer/113770?hl=en) documentation.
+
+Unlike Apple, Google does not ask for compliance documentation.  Your app is expected to follow U.S. regulations.
+
+# Your app's compliance
+It is important for you to determine your app's compliance. See the [Encryption and Export Administration Regulations (EAR)](https://www.bis.doc.gov/index.php/policy-guidance/encryption) website for more details.
+

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -12,5 +12,6 @@ nav:
   - App Store Connect API Key: app_store_connect_api_key.md
   - Google App Signing: google_app_signing.md
   - Google Signing For React Native Apps: google_react_native_signing.md
+  - Encryption Export Regulations: encryption.md
 plugins:
   - techdocs-core


### PR DESCRIPTION
This page is from the [exporting-encryption](https://developer.gov.bc.ca/Mobile-Starter-Kit-Overview#exporting-encryption) section of the mobile developers starter kit.

I've made the following changes from that document:
* removed reference to the "over 63 bytes" statement. That [requirement has changed](https://www.bis.doc.gov/index.php/policy-guidance/encryption/2-items-in-cat-5-part-2/a-5a002-a-and-5d002-c-1/ii-key-length).
* Removed the section about requiring export compliance even if the app is only available in Canada. This is because the [Apple documentation](https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations) states that export compliance is only needed if the app is distributed outside of the U.S. or **Canada**.