### PR TITLE
How to publish an app to the app stores

### DIFF
--- a/docs/app_store_connect_api_key.md
+++ b/docs/app_store_connect_api_key.md
@@ -1,1 +1,0 @@
-# Apple App Store Connect API Key

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,6 +1,6 @@
 # Publish your app
 
-This page describes how to setup your CI/CD pipeline to upload your app to App Store Connect and Play Console.
+Learn how to setup your CI/CD pipeline to upload your app to App Store Connect and Play Console.
 
 ## Distribution methods
 

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,29 +1,32 @@
 # Publish your app
 
+This page describes how to setup your CI/CD pipeline to upload your app to App Store Connect and Play Console.
+
 ## Distribution methods
 
-See the [Mobile App Distribution Methods](distribution_methods.md)  page for an overview of app distribution.
+Review [Mobile App Distribution Methods](distribution_methods.md) for an overview of app distribution.
 
 ## CI/CD
 
-Let the [Developer Experience](contact.md) team know your app will use a CI/CD pipeline to upload your app. We will give you access to the necessary API keys.
+Let the [Developer Experience](contact.md) team know if your app will use a CI/CD pipeline to upload your app. We'll give you access to the necessary API keys.
 
-See the [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/) project as an example of an app using GitHub Actions to upload to both app stores.
+ The [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/) project is a good example of an app using GitHub Actions to upload to both app stores.
 
 ## App Store Connect
 
 Let us know if you plan to:
 
-1. upload the build, or,
-1. upload the build and ship it to TestFlight
+1. Upload the build
+or
+1. Upload the build and ship it to TestFlight
 
-The answer to the above will determine which API Key to use.
+The upload path you pick determines which API Key to use. 
 
-The bcgov GitHub organization stores the [App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi) keys as secrets. Send the [Developer Experience](contact.md) team your repo name and we will give it access to those secrets.
+The bcgov GitHub organization stores the [App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi) keys as secrets. Send the [Developer Experience](contact.md) team your repo name and we'll give it access to those secrets.
 
-You can use [codemagic-cli-tools](https://docs.codemagic.io/knowledge-codemagic/codemagic-cli-tools/) to upload your app. See the [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/) project as an example.
+You can use [codemagic-cli-tools](https://docs.codemagic.io/knowledge-codemagic/codemagic-cli-tools/) to upload your app. 
 
 ## Play Console
-See the [Developer Experience](contact.md) team to setup your API Key to the Play Console.
+Contact the [Developer Experience](contact.md) team to setup your API Key to the Play Console.
 
-You can use the `npx @bcgov/gpublish` package to upload your app. See the [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/) project as an example.
+You can use the `npx @bcgov/gpublish` package to upload your app. 

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,16 +1,29 @@
-# Publish Your App 
+# Publish your app
 
 ## Distribution methods
-Please see the [Mobile App Distribution Methods](distribution_methods.md) page for an overview of how apps are distributed. 
 
+See the [Mobile App Distribution Methods](distribution_methods.md)  page for an overview of app distribution.
 
 ## CI/CD
-If you are using GitHub Actions as the CI/CD pipeline for your app, then you can upload the build artifact to both App Store Connect and Play Console from your pipeline. Let the [Developer Experience](contact.md) team know so we can give access to the API keys.
 
-See the [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/blob/main/.github/workflows/main.yaml) project as an example.
+Let the [Developer Experience](contact.md) team know your app will use a CI/CD pipeline to upload your app. We will give you access to the necessary API keys.
 
-### App Store Connect
-Let us know if you plan to just upload the build, or if you want to ship it to TestFlight. The credentials are stored in the bcgov organizations secrets. We will grant your repository access to them. 
+See the [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/) project as an example of an app using GitHub Actions to upload to both app stores.
 
-### Play Console
+## App Store Connect
 
+Let us know if you plan to:
+
+1. upload the build, or,
+1. upload the build and ship it to TestFlight
+
+The answer to the above will determine which API Key to use.
+
+The bcgov GitHub organization stores the [App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi) keys as secrets. Send the [Developer Experience](contact.md) team your repo name and we will give it access to those secrets.
+
+You can use [codemagic-cli-tools](https://docs.codemagic.io/knowledge-codemagic/codemagic-cli-tools/) to upload your app. See the [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/) project as an example.
+
+## Play Console
+See the [Developer Experience](contact.md) team to setup your API Key to the Play Console.
+
+You can use the `npx @bcgov/gpublish` package to upload your app. See the [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/) project as an example.

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,0 +1,16 @@
+# Publish Your App 
+
+## Distribution methods
+Please see the [Mobile App Distribution Methods](distribution_methods.md) page for an overview of how apps are distributed. 
+
+
+## CI/CD
+If you are using GitHub Actions as the CI/CD pipeline for your app, then you can upload the build artifact to both App Store Connect and Play Console from your pipeline. Let the [Developer Experience](contact.md) team know so we can give access to the API keys.
+
+See the [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/blob/main/.github/workflows/main.yaml) project as an example.
+
+### App Store Connect
+Let us know if you plan to just upload the build, or if you want to ship it to TestFlight. The credentials are stored in the bcgov organizations secrets. We will grant your repository access to them. 
+
+### Play Console
+

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -9,8 +9,8 @@ nav:
   - Distribution Methods: distribution_methods.md
   - App Management: app_management.md
   - Apple App Signing: apple_app_signing.md
-  - App Store Connect API Key: app_store_connect_api_key.md
   - Google App Signing: google_app_signing.md
   - Google Signing For React Native Apps: google_react_native_signing.md
+  - Publish your app: publish.md
 plugins:
   - techdocs-core


### PR DESCRIPTION
This page is a rewrite of the [Apple API Key Usage](https://github.com/bcgov/mobile-signing-service/wiki/Apple-API-Key-Usage) page. That page was focused on how a member of the Developer Experience team would create an API Key. I rewrote the page to focus on the user.

