### PR TITLE
Google signing for React Native apps

### DIFF
--- a/docs/google_react_native_signing.md
+++ b/docs/google_react_native_signing.md
@@ -1,1 +1,73 @@
-# google react native signing
+# Google Signing For React Native Apps
+
+## Prerequisite
+Your app must be setup to use [Google Play App Signing](Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play) and have an [upload key](). Please see the [Google App Signing](google_app_signing.md) guide for more details.
+
+## Modify Gradle Files and Sign Release
+
+Now that we got the upload key generated we need to modify the gradle files to have a release config for production builds. The configuration below relies on a .env file that stores:
+
+* KEYSTORE={fileNameFromAbove}.keystore
+* KEY_ALIAS={alias-from-above}
+* STORE_PASSWORD={password-from-above}
+* KEY_PASSWORD={password-from-above}
+
+> MAKE SURE NOT TO COMMIT THE .ENV FILE
+
+On the file build.gradle add a **release** config under signing config:
+
+```javascript
+signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+        release {
+            // We can leave these in environment variables
+            storeFile file("$System.env.KEYSTORE")
+            keyAlias "$System.env.KEY_ALIAS"
+            storePassword "$System.env.STORE_PASSWORD"
+            keyPassword "$System.env.KEY_PASSWORD"
+        }
+    }
+```
+
+Additionally, we need to tell Gradle to use our new config for release builds:
+
+```js
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Using release from above
+            signingConfig signingConfigs.release
+        }
+    }
+```
+
+Alternatively, you can [sign your release from Android Studio](https://developer.android.com/studio/publish/app-signing#sign_release).
+
+## Build and Upload
+
+Now that we got Gradle setup, we can run from the Android folder:
+
+`./gradlew bundleRelease assembleRelease`
+
+If everything goes well, you will see something like:
+
+![](https://github.com/bcgov/mobile-signing-service/blob/master/wiki-page-assets/react-native-4.1.png)
+
+You will then find a .aab build under app/build/outputs/bundle/release
+
+Navigate to the Google Play Console, and select the app for which you just build a release. Then select Internal Testing -> Edit Release -> Drag and drop the .aab bundle.
+
+![](https://github.com/bcgov/mobile-signing-service/blob/master/wiki-page-assets/react-native-4.2.png)
+
+Google will then give you more info on your app and will present any warning or errors you need to address. Once all that is done, and you start internal testing you will be able to see them under Releases. 
+
+![](https://github.com/bcgov/mobile-signing-service/blob/master/wiki-page-assets/react-native-4.3.png)
+
+For any future releases, you will just need to update the build number, rebuild using Gradle, and upload to Google.

--- a/docs/google_react_native_signing.md
+++ b/docs/google_react_native_signing.md
@@ -1,20 +1,28 @@
 # Google Signing For React Native Apps
 
 ## Prerequisite
-Your app must be setup to use [Google Play App Signing](Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play) and have an [upload key](). Please see the [Google App Signing](google_app_signing.md) guide for more details.
+Your app must be setup to use [Google Play App Signing](Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play) and have an [upload key](https://developer.android.com/studio/publish/app-signing#sign-apk). Please see the [Google App Signing](google_app_signing.md) guide for more details.
 
 ## Modify Gradle Files and Sign Release
 
-Now that we got the upload key generated we need to modify the gradle files to have a release config for production builds. The configuration below relies on a .env file that stores:
+Once the prerequisites are met, modify the gradle files to have a release config for production builds. The configuration below assumes the production build will be run from a GitHub Action. It assumes the following are setup as secrets in your GitHub repo.
 
 * KEYSTORE={fileNameFromAbove}.keystore
 * KEY_ALIAS={alias-from-above}
 * STORE_PASSWORD={password-from-above}
 * KEY_PASSWORD={password-from-above}
 
-> MAKE SURE NOT TO COMMIT THE .ENV FILE
+Example:
+```yaml
+ - name: Build APK
+   run: ./gradlew bundleRelease assembleRelease
+   env:
+     KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+     STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+     KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+```
 
-On the file build.gradle add a **release** config under signing config:
+In the `build.gradle` file add a `release` config under signing config:
 
 ```javascript
 signingConfigs {
@@ -45,8 +53,9 @@ Additionally, we need to tell Gradle to use our new config for release builds:
             // Using release from above
             signingConfig signingConfigs.release
         }
-    }
+    }    
 ```
+
 
 Alternatively, you can [sign your release from Android Studio](https://developer.android.com/studio/publish/app-signing#sign_release).
 

--- a/docs/google_react_native_signing.md
+++ b/docs/google_react_native_signing.md
@@ -1,29 +1,37 @@
 # Google signing for React Native apps
 
+Learn how to setup Google signing in a CI/CD pipeline using GitHub Actions.
 
-Refer to React Native's [Publishing to Google Play Store](https://reactnative.dev/docs/signed-apk-android) guide for an overview of app signing. That guide describes how to sign an app from a developer's computer. This page describes how to setup those steps in a CI/CD pipeline using GitHub Actions.
+Need a general overview of what app signing is? Review React Native's [Publishing to Google Play Store](https://reactnative.dev/docs/signed-apk-android) guide which describes how to sign an app from a developer's computer. 
 
-## Prerequisite
+Follow these steps to sign your React Native app:
+
+1. [Setup Google Play App Signing](google_react_native_signing.md#setup-google-play-app-signing)
+1. [Create the upload key](google_react_native_signing.md#create-the-upload-key)
+1. [Update Gradle files ](google_react_native_signing.md#update-gradle-files)
+1. [Setup GitHub Action](google_react_native_signing.md#github-action)
+1. [Upload the build](google_react_native_signing.md#upload-the-build)
+
+## Setup Google Play App Signing
 Your app must be setup to use [Google Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play).
 
 ## Create the upload key
 Follow React Native's [instructions to generate an upload key](https://reactnative.dev/docs/signed-apk-android#generating-an-upload-key).
 
 
-## Setup GitHub secrets
+In your app's GitHub repo, setup 4 secrets:
 
-In your app's GitHub repo, setup the following secrets:
+* ANDROID_UPLOAD_KEYSTORE_BASE64={file-name-from-above}.keystore - encoded as base64
+* ANDROID_KEY_ALIAS={alias-from-above}
+* ANDROID_SIGNING_STORE_PASSWORD={password-from-above}
+* ANDROID_SIGNING_KEY_PASSWORD={password-from-above}
 
-* ANDROID_UPLOAD_KEYSTORE_BASE64={file-name-from-above-step}.keystore - encoded as base64
-* ANDROID_KEY_ALIAS={alias-from-above-step}
-* ANDROID_SIGNING_STORE_PASSWORD={password-from-above-step}
-* ANDROID_SIGNING_KEY_PASSWORD={password-from-above-step}
+To encode the keystore file as base64, use this command:
 
-Use the following command to encode the keystore file as base64:
 `base64 -i your-keystore-file.keystore | pbcopy`
 
 
-## Update Gradle Files 
+## Update Gradle files 
 
 In the `android/app/build.gradle` file add a `release` config under `signingConfigs`. 
 
@@ -46,7 +54,7 @@ signingConfigs {
     }
 ```
 
-Additionally, we need to tell Gradle to use our new config for release builds:
+You also need to tell Gradle to use the new config for release builds:
 
 ```js
     buildTypes {
@@ -72,7 +80,9 @@ defaultConfig {
 
 ## GitHub Action
 
- See the [bc-mobile-wallet](https://github.com/bcgov/bc-wallet-mobile) project for a complete GitHub Action workflow. Below is a basic GitHub Action.
+Review the [bc-mobile-wallet](https://github.com/bcgov/bc-wallet-mobile) project for a complete GitHub Action workflow. 
+
+Example of a basic GitHub Action:
 
 ```yaml
 name: Build
@@ -136,10 +146,10 @@ jobs:
 
 ## Upload the build
 
-### GitHub Action Upload
-See the [Publish Your App](publish.md) page for information on how to upload from your CI/CD pipeline.
+### GitHub Action upload
+Review the [Publish Your App](publish.md) page for information on how to upload from your CI/CD pipeline.
 
-### Manual Upload
+### Manual upload
 
 To upload the file:
 


### PR DESCRIPTION
This is a rewrite of the [Google Signing for React Native Application](https://github.com/bcgov/mobile-signing-service/wiki/Google-Signing-for-React-Native-Application).

I updated it to describe how to do the signing in a CI/CD pipeline, rather than from a developer's desktop.

I removed the steps on how to navigate in Google Play Console. I provided a link to the google documentation instead.