### PR TITLE
Updates to signing and distribution methods

### DIFF
--- a/docs/apple_app_signing.md
+++ b/docs/apple_app_signing.md
@@ -46,7 +46,7 @@ To use a GitHub Actions to build and sign your app:
   1. Refer to GitHub's [Installing an Apple certificate on macOS runners for Xcode development](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development) documentation for details
 1. In the Signing & Capabilities -> Release tab in Xcode:
   1. Turn off "automatically manage signing" 
-  1. Select the new provisioning profile in the "Provisioning Profile" drop down box
+  1. Select the new provisioning profile in the "Provisioning Profile" drop-down box
 1. Setup [export options](#exportoptionsplist)
 1. Create [the GitHub Action](#example)
 

--- a/docs/apple_app_signing.md
+++ b/docs/apple_app_signing.md
@@ -39,12 +39,14 @@ To use a GitHub Actions to build and sign your app:
 
 1. Send your GitHub repo's name to the [Developer Experience team](contact.md). 
 1. We will give it access to the following secrets:
-  1. `BUILD_CERTIFICATE_BASE64`
-  1. `IOS_BUILD_CERTIFICATE_PASSWD`
+  1. `APPLE_APP_STORE_BUILD_CERTIFICATE_BASE64`
+  1. `APPLE_APP_STORE_BUILD_CERTIFICATE_PASSWD`
 1. Create and download the provisioning profile for your app
 1. Install the provisioning profile as a secret in your repo
   1. Refer to GitHub's [Installing an Apple certificate on macOS runners for Xcode development](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development) documentation for details
-1. In the Signing & Capabilities -> Release tab in Xcode turn off "automatically manage signing" 
+1. In the Signing & Capabilities -> Release tab in Xcode:
+  1. Turn off "automatically manage signing" 
+  1. Select the new provisioning profile in the "Provisioning Profile" drop down box
 1. Setup [export options](#exportoptionsplist)
 1. Create [the GitHub Action](#example)
 
@@ -138,8 +140,8 @@ jobs:
       - name: Install the Apple certificate and provisioning profile
         env:
           # The first two keys are from the bcgov organization secrets
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.IOS_BUILD_CERTIFICATE_PASSWD }}
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.APPLE_APP_STORE_BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.APPLE_APP_STORE_BUILD_CERTIFICATE_PASSWD }}
           # These two keys are from your app's repo secrets
           BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.IOS_PROVISION_PROFILE_BASE64 }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}

--- a/docs/distribution_methods.md
+++ b/docs/distribution_methods.md
@@ -4,6 +4,7 @@ Mobile apps are distributed through the public app stores or MDM InTune. Your di
 
 ![Diagram of the various distribution methods. If the app is for the general public, it's distributed via the Apple App Store and Google Play Stores. If it's an app for Government employees, it's distributed via MDM inTunes. If it's an app for Employees and Contractors it is distributed as an unlisted app via the Apple App Store.](assets/distribution.drawio.svg)
 
+## Public apps
 Public apps are released through the Province's accounts on the Apple App Store and Google Play Store. 
 
 You must list your app through the Province's accounts. The [Developer Experience team](contact.md) helps you get your app on these accounts.
@@ -11,6 +12,13 @@ You must list your app through the Province's accounts. The [Developer Experienc
 Before contacting the Developer Experience team, we recommend reviewing the [project initiation information](getting_started.md).
 
 Once setup is complete, you'll have access to [App Store Connect](https://appstoreconnect.apple.com) and [Google Play Console](https://play.google.com/console/about/) to manage your app.
+
+## Internal apps
+Employee apps are distributed through [MDM inTune by the OCIO Device Management Team](https://citz.sp.gov.bc.ca/sites/ES/DS/MDAS/Docs/SitePages/Home.aspx). While historically, employee apps only supported iOS devices, they're now also supported by Android. If you're planning to create an internal Android app, [contact us](contact.md). 
+
+[Contact us](contact.md) at the start of your project so we can discuss the process for distributing an internal app. It requires setup from both the Developer Experience and OCIO Device Management teams.
+
+Apps used by both employees and contractors also need extra setup in Apple's App Store Connect. The [Developer Experience Team](contact.md) will assist in this setup.
 
 ## App review process
 Both the Apple App Store and Google Play Store have an app review process. 
@@ -21,9 +29,7 @@ If you believe your internal app can't go through the app review process, contac
 
 Consult the [Apple app guidelines](https://developer.apple.com/app-store/review/) and [Google app guidelines](https://support.google.com/googleplay/android-developer/answer/9859455?hl=en&ref_topic=7072031&sjid=10634496881788336983-NA) when preparing your app's release. It's important to follow their guidelines to ensure a smooth review process.
 
-Employee apps are distributed through [MDM inTune by the OCIO Device Management Team](https://citz.sp.gov.bc.ca/sites/ES/DS/MDAS/Docs/SitePages/Home.aspx). While historically, employee apps only supported iOS devices, they're now also supported by Android. If you're planning to create an internal Android app, [contact us](contact.md). 
 
-Employee and contractor apps also need extra setup in Apple's App Store Connect. The [Developer Experience Team](contact.md) will assist in this setup.
 
 ## Beta testing distribution
 

--- a/docs/google_app_signing.md
+++ b/docs/google_app_signing.md
@@ -1,6 +1,5 @@
 # Google app signing
 
-
 This guide describes how an app team should work with Google keys. You must use the Province of BC's Google Play developer account to distribute your app.
 
 To learn about code signing, review Google's [Sign your app](https://developer.android.com/studio/publish/app-signing) documentation.
@@ -30,6 +29,9 @@ The [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/blob/main/.gith
 If you're using a different git host, review its documentation on how to create a CI/CD pipeline. Use its secret feature to store the key and password securely.
 
 If you don't use a CI/CD pipeline, store the key and password somewhere securely. 
+
+You may request an upload key reset if the key is lost. Access to this feature is restricted by Google. The account holder from the Developer Experience team will submit the reset request. [Contact us](contact.md) to start this process.
+
 We encourage teams to use a CI/CD pipeline. It provides repeatable builds and safely stores the credentials.
 
 ### App Signing Key


### PR DESCRIPTION
Some minor updates to the documentation:

* [Apple app signing](https://dev.developer.gov.bc.ca/docs/default/component/mobile-developer-guide/apple_app_signing/)
  * Updated the secret key names. They were updated in the bcgov GitHub org to make the names clearer to their purpose. Updated the documentation to reflect that change
* [Distribution methods](https://dev.developer.gov.bc.ca/docs/default/component/mobile-developer-guide/distribution_methods/) 
  * Added in a sentence reflecting that both OCIO Mobile Device and Developer Experience teams need to take steps in setting up an internal app for distribution
  * Added headers to sections to help break up the content
* [Google app signing](https://dev.developer.gov.bc.ca/docs/default/component/mobile-developer-guide/google_app_signing/)
  * Added documentation on how to regenerate an upload key 

The linked pages contain the updates on the dev site.