### PR TITLE
Updated with more signing and storage examples

### DIFF
--- a/docs/apple_app_signing.md
+++ b/docs/apple_app_signing.md
@@ -261,9 +261,9 @@ jobs:
   1. Using the `actions/upload-artifact` action will store it on GitHub.
   1. **Warning:** If this is in a public repository, the artifact will be publicly accessible. Anyone can download it.
 1. S3
-  1. This example uses [S3-compatible Object Storage](docs/default/component/platform-developer-docs/docs/platform-architecture-reference/platform-storage/#s3-compatible-object-storage-dell-emc-elastic-cloud-storage)
+  1. This example uses [S3-compatible Object Storage](/docs/default/component/platform-developer-docs/docs/platform-architecture-reference/platform-storage/#s3-compatible-object-storage-dell-emc-elastic-cloud-storage)
 1. Artifactory
-  1. [Learn how to setup Artifactory](docs/default/component/platform-developer-docs/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository/)
+  1. [Learn how to setup Artifactory](/docs/default/component/platform-developer-docs/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository/)
   1. Use Artifactory if your app is an [internal app](distribution_methods.md#internal-apps). [Contact us](contact.md) for help with setting it up.
 
 

--- a/docs/google_app_signing.md
+++ b/docs/google_app_signing.md
@@ -33,7 +33,7 @@ Use the [Play App Signing](https://developer.android.com/studio/publish/app-sign
 
 ## Automated build and signing
 
-Automate your app's build and signing process by using a [GitHub workflow](](https://docs.github.com/en/actions)):
+Automate your app's build and signing process by using a [GitHub workflow](https://docs.github.com/en/actions):
 
 - Store the upload key ([encoded as base64](https://docs.github.com/en/actions/security-guides/encrypted-secrets#storing-base64-binary-blobs-as-secrets)), its alias and the password as a [secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) in your app's repo. 
 - The [Google signing for React Native apps](google_react_native_signing.md#github-action) page provides an example workflow

--- a/docs/google_app_signing.md
+++ b/docs/google_app_signing.md
@@ -19,22 +19,25 @@ Use Google's [Play App Signing](https://developer.android.com/studio/publish/app
 
 The upload key signs your app for upload to the Google Play Store. The team's app release manager should [create the upload key](https://developer.android.com/studio/publish/app-signing#sign-apk). 
 
-If your app's code is in the [bcgov GitHub organization](https://github.com/bcgov), use a [GitHub Action](https://docs.github.com/en/actions) to build and sign your app with the upload key. 
-
-Refer to Google's [Sign your app from command line](https://developer.android.com/build/building-cmdline#sign_cmdline) documentation for instructions on how to do this. Store the key ([encoded as base64](https://docs.github.com/en/actions/security-guides/encrypted-secrets#storing-base64-binary-blobs-as-secrets)), its alias and the password as a [secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) in your app's repo. 
+Securely store the key and its password. 
 
 
-The [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/blob/main/.github/workflows/main.yaml) project is a good example of a project using GitHub Actions.
+You may request to reset an upload key if it is lost. Only the account holder from the Developer Experience team can submit the reset request. [Contact us](contact.md) to start this process.
 
-If you're using a different git host, review its documentation on how to create a CI/CD pipeline. Use its secret feature to store the key and password securely.
 
-If you don't use a CI/CD pipeline, store the key and password somewhere securely. 
-
-You may request an upload key reset if the key is lost. Access to this feature is restricted by Google. The account holder from the Developer Experience team will submit the reset request. [Contact us](contact.md) to start this process.
-
-We encourage teams to use a CI/CD pipeline. It provides repeatable builds and safely stores the credentials.
 
 ### App Signing Key
 
 Use the [Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play) service to sign your app. If you don't use this service and you lose your app’s signing key, you lose the ability to update your app. Google's [Using Play App Signing](https://developer.android.com/studio/publish/app-signing#enroll) documentation describes how to set it up for your app.
 
+
+## Automated build and signing
+
+Automate your app's build and signing process by using a [GitHub workflow](](https://docs.github.com/en/actions)):
+
+- Store the upload key ([encoded as base64](https://docs.github.com/en/actions/security-guides/encrypted-secrets#storing-base64-binary-blobs-as-secrets)), its alias and the password as a [secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) in your app's repo. 
+- The [Google signing for React Native apps](google_react_native_signing.md#github-action) page provides an example workflow
+  - If you're not using React Native, refer to Google's [Sign your app from command line](https://developer.android.com/build/building-cmdline) documentation to create a workflow that signs your app.
+- The [bc-wallet-mobile](https://github.com/bcgov/bc-wallet-mobile/blob/main/.github/workflows/main.yaml) project is a good example of a project using GitHub Actions.
+
+We encourage teams to use a CI/CD pipeline. It provides repeatable builds and safely stores the credentials.

--- a/docs/google_react_native_signing.md
+++ b/docs/google_react_native_signing.md
@@ -198,9 +198,9 @@ jobs:
   1. Using the `actions/upload-artifact` action will store it on GitHub.
   1. **Warning:** If this is in a public repository, the artifact will be publicly accessible. Anyone can download it.
 1. S3
-  1. This example uses [S3-compatible Object Storage](docs/default/component/platform-developer-docs/docs/platform-architecture-reference/platform-storage/#s3-compatible-object-storage-dell-emc-elastic-cloud-storage)
+  1. This example uses [S3-compatible Object Storage](/docs/default/component/platform-developer-docs/docs/platform-architecture-reference/platform-storage/#s3-compatible-object-storage-dell-emc-elastic-cloud-storage)
 1. Artifactory
-  1. [Learn how to setup Artifactory](docs/default/component/platform-developer-docs/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository/)
+  1. [Learn how to setup Artifactory](/docs/default/component/platform-developer-docs/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository/)
   1. Use Artifactory if your app is an [internal app](distribution_methods.md#internal-apps). [Contact us](contact.md) for help with setting it up. for help with setting it up.
 
 


### PR DESCRIPTION
Updated with the following

- Additional examples of storing the build artifact
- Example of extracting certificate name 
- Reorganized google signing docs
