### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,9 @@
 name: Publish TechDocs
 
+permissions:
+  contents: read
+
 on:
-  workflow_dispatch:
   push: 
     branches: [main] 
     paths:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push: 
     branches: [main] 
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/mobile-developer-guide/security/code-scanning/1](https://github.com/bcgov/mobile-developer-guide/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily interacts with repository contents and uses secrets for publishing TechDocs. Therefore, we will set `contents: read` to allow read-only access to repository contents and avoid granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
